### PR TITLE
feat: in-app RSVP notifications for host family

### DIFF
--- a/packages/frontend/src/components/Calendar/EventRSVPButton.jsx
+++ b/packages/frontend/src/components/Calendar/EventRSVPButton.jsx
@@ -2,12 +2,9 @@ import React, { useEffect, useState } from 'react'
 import { Button, Typography } from '@material-tailwind/react'
 import { CheckIcon, XMarkIcon, QuestionMarkCircleIcon } from '@heroicons/react/24/outline'
 import { useEventAttendeesStore, useEventAttendeesSelectors } from '@/store/useEventAttendeesStore'
-import { useFamilyStore } from '@/store/useFamilyGroupStore'
 import { useProfileStore } from '@/store/useProfileStore'
 import { useAuthStore } from '@/store/useAuthStore'
 import { toast } from 'react-toastify'
-
-const env = import.meta.env
 
 // The three RSVP choices
 const RSVP_OPTIONS = [
@@ -25,25 +22,9 @@ const RSVP_TEXT_COLOR = {
   no: 'text-red-600 dark:text-red-400'
 }
 
-// Fire a Telegram alert with the family's RSVP choice (best-effort)
-const sendRSVPAlert = ({ eventId, eventTitle, familyName, status }) => {
-  if (!env.VITE_TELEGRAM_ACTION_URL) return
-  fetch(`${env.VITE_TELEGRAM_ACTION_URL}`, {
-    method: 'POST',
-    body: JSON.stringify({
-      action: 'rsvp',
-      rsvpStatus: status,
-      familyName: familyName || 'A family',
-      event: { id: eventId, event_title: eventTitle },
-      origin: window.location.origin
-    })
-  }).catch(err => console.error('Failed to send RSVP alert:', err))
-}
-
-export const EventRSVPButton = ({ eventId, eventTitle, onRSVPChange }) => {
+export const EventRSVPButton = ({ eventId, onRSVPChange }) => {
   const { user: authUser } = useAuthStore()
   const { profile } = useProfileStore()
-  const { familyGroup } = useFamilyStore()
   const { setRSVP, fetchEventAttendees } = useEventAttendeesStore()
 
   // Current RSVP choice + count
@@ -76,12 +57,6 @@ export const EventRSVPButton = ({ eventId, eventTitle, onRSVPChange }) => {
       const result = await setRSVP(eventId, profile.family_id, status)
       if (result) {
         toast.success(`RSVP saved: ${STATUS_LABEL[status]}`)
-        sendRSVPAlert({
-          eventId,
-          eventTitle,
-          familyName: familyGroup?.family_last_name || profile?.family_last_name,
-          status
-        })
         if (onRSVPChange) {
           // Get the post-update attendee count from the store
           const newAttendeeCount = useEventAttendeesStore.getState().getEventAttendeeCount(eventId)
@@ -208,10 +183,9 @@ export const EventRSVPButton = ({ eventId, eventTitle, onRSVPChange }) => {
 }
 
 // Alternative: Simple RSVP Button (minimal yes/maybe/no version)
-export const SimpleRSVPButton = ({ eventId, eventTitle, className = "" }) => {
+export const SimpleRSVPButton = ({ eventId, className = "" }) => {
   const { user: authUser } = useAuthStore()
   const { profile } = useProfileStore()
-  const { familyGroup } = useFamilyStore()
   const { setRSVP } = useEventAttendeesStore()
 
   const rsvpStatus = useEventAttendeesSelectors.useFamilyRSVPStatus(eventId, profile?.family_id)
@@ -228,12 +202,6 @@ export const SimpleRSVPButton = ({ eventId, eventTitle, className = "" }) => {
       const result = await setRSVP(eventId, profile.family_id, status)
       if (result) {
         toast.success(`RSVP saved: ${STATUS_LABEL[status]}`)
-        sendRSVPAlert({
-          eventId,
-          eventTitle,
-          familyName: familyGroup?.family_last_name || profile?.family_last_name,
-          status
-        })
       }
     } catch (error) {
       toast.error(error.message || 'Failed to update RSVP')

--- a/packages/frontend/src/components/Notifications/NotificationBell.jsx
+++ b/packages/frontend/src/components/Notifications/NotificationBell.jsx
@@ -1,0 +1,136 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { BellIcon } from "@heroicons/react/24/outline";
+import { useAuthStore } from "@store/useAuthStore";
+import { useProfileStore } from "@store/useProfileStore";
+import { useNotificationsStore } from "@store/useNotificationsStore";
+
+const RSVP_TEXT = {
+  yes: "is attending",
+  maybe: "might attend",
+  no: "is not attending",
+};
+
+const timeAgo = (iso) => {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+};
+
+export const NotificationBell = () => {
+  const navigate = useNavigate();
+  const { isAuthenticated } = useAuthStore();
+  const { profile } = useProfileStore();
+  const familyId = profile?.family_id;
+
+  const notifications = useNotificationsStore((s) => s.notifications);
+  const unread = useNotificationsStore((s) => s.unreadCount());
+  const init = useNotificationsStore((s) => s.init);
+  const teardown = useNotificationsStore((s) => s.teardown);
+  const markRead = useNotificationsStore((s) => s.markRead);
+  const markAllRead = useNotificationsStore((s) => s.markAllRead);
+
+  const [open, setOpen] = useState(false);
+  const ref = useRef(null);
+
+  // Subscribe while authenticated with a family; tear down otherwise.
+  useEffect(() => {
+    if (isAuthenticated && familyId) {
+      init(familyId);
+    } else {
+      teardown();
+    }
+  }, [isAuthenticated, familyId, init, teardown]);
+
+  // Close the panel on outside click.
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, [open]);
+
+  if (!isAuthenticated || !familyId) return null;
+
+  const handleOpen = (n) => {
+    markRead(n.id);
+    setOpen(false);
+    if (n.event_id) navigate(`/events/${n.event_id}`);
+  };
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-label="Notifications"
+        className="relative flex items-center justify-center w-9 h-9 rounded-md text-white/90 hover:bg-white/10 transition-colors"
+      >
+        <BellIcon className="w-6 h-6" />
+        {unread > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 flex items-center justify-center rounded-full bg-red-500 text-white text-[11px] font-bold leading-none">
+            {unread > 9 ? "9+" : unread}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 mt-2 w-80 max-w-[calc(100vw-2rem)] bg-white dark:bg-gray-800 rounded-lg shadow-xl ring-1 ring-black/5 z-50 overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-2.5 border-b border-gray-100 dark:border-gray-700">
+            <span className="font-semibold text-gray-800 dark:text-gray-100 text-sm">
+              Notifications
+            </span>
+            {unread > 0 && (
+              <button
+                onClick={markAllRead}
+                className="text-xs text-[#0e9496] hover:underline"
+              >
+                Mark all read
+              </button>
+            )}
+          </div>
+
+          <div className="max-h-96 overflow-y-auto">
+            {notifications.length === 0 ? (
+              <p className="px-4 py-8 text-center text-sm text-gray-400">
+                No notifications yet.
+              </p>
+            ) : (
+              notifications.map((n) => (
+                <button
+                  key={n.id}
+                  onClick={() => handleOpen(n)}
+                  className={`w-full text-left px-4 py-3 border-b border-gray-50 dark:border-gray-700/50 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors ${
+                    n.is_read ? "" : "bg-[#0e9496]/5"
+                  }`}
+                >
+                  <p className="text-sm text-gray-800 dark:text-gray-100">
+                    <span className="font-semibold">
+                      The {n.actor_family_name || "A"} family
+                    </span>{" "}
+                    {RSVP_TEXT[n.rsvp_status] || "responded"}
+                    {n.event_title ? (
+                      <>
+                        {" "}
+                        <span className="font-medium">{n.event_title}</span>
+                      </>
+                    ) : null}
+                    .
+                  </p>
+                  <span className="text-xs text-gray-400">
+                    {timeAgo(n.created_at)}
+                  </span>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/frontend/src/components/Shared/Nav/Nav.jsx
+++ b/packages/frontend/src/components/Shared/Nav/Nav.jsx
@@ -1,5 +1,6 @@
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAuthStore } from "@store/useAuthStore";
+import { NotificationBell } from "@components/Notifications/NotificationBell";
 
 const navLinks = [
   { label: "Readings", path: "/" },
@@ -29,8 +30,11 @@ export const Nav = () => {
     <div className="bg-[#0e9496] px-5 h-14 flex items-center justify-between shrink-0">
       <span className="text-white font-bold text-lg">Fellowship 🕎</span>
 
-      {/* Desktop nav links */}
-      <nav className="hidden md:flex items-center gap-1">
+      <div className="flex items-center gap-1">
+        <NotificationBell />
+
+        {/* Desktop nav links */}
+        <nav className="hidden md:flex items-center gap-1">
         {navLinks.map((link) => {
           const isActive =
             link.path === "/"
@@ -63,7 +67,8 @@ export const Nav = () => {
         >
           {isAuthenticated ? "Account" : "Sign In"}
         </button>
-      </nav>
+        </nav>
+      </div>
     </div>
   );
 };

--- a/packages/frontend/src/store/useNotificationsStore.js
+++ b/packages/frontend/src/store/useNotificationsStore.js
@@ -1,0 +1,92 @@
+import { create } from 'zustand'
+import { supabase } from '@/supabaseClient'
+
+// In-app notifications for the host family (e.g. "the Smith family is attending").
+// Rows are created server-side by a trigger on event_attendees and streamed here
+// via Supabase Realtime.
+export const useNotificationsStore = create((set, get) => ({
+  // State
+  notifications: [],
+  loading: false,
+  error: null,
+  familyId: null,
+  _channel: null,
+
+  unreadCount: () => get().notifications.filter((n) => !n.is_read).length,
+
+  // Load the family's notifications and subscribe to new ones.
+  init: async (familyId) => {
+    if (!familyId || get().familyId === familyId) return
+    get().teardown()
+    set({ familyId, loading: true, error: null })
+
+    const { data, error } = await supabase
+      .from('event_notifications')
+      .select('*')
+      .eq('recipient_family_id', familyId)
+      .order('created_at', { ascending: false })
+      .limit(50)
+
+    if (error) {
+      console.error('Error fetching notifications:', error)
+      set({ error: error.message, loading: false })
+    } else {
+      set({ notifications: data || [], loading: false })
+    }
+
+    const channel = supabase
+      .channel(`notifications:${familyId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'event_notifications',
+          filter: `recipient_family_id=eq.${familyId}`
+        },
+        (payload) => {
+          set((state) => {
+            if (state.notifications.some((n) => n.id === payload.new.id)) return state
+            return { notifications: [payload.new, ...state.notifications] }
+          })
+        }
+      )
+      .subscribe()
+
+    set({ _channel: channel })
+  },
+
+  markRead: async (id) => {
+    const target = get().notifications.find((n) => n.id === id)
+    if (!target || target.is_read) return
+    set((state) => ({
+      notifications: state.notifications.map((n) =>
+        n.id === id ? { ...n, is_read: true } : n
+      )
+    }))
+    const { error } = await supabase
+      .from('event_notifications')
+      .update({ is_read: true })
+      .eq('id', id)
+    if (error) console.error('Error marking notification read:', error)
+  },
+
+  markAllRead: async () => {
+    const unreadIds = get().notifications.filter((n) => !n.is_read).map((n) => n.id)
+    if (unreadIds.length === 0) return
+    set((state) => ({
+      notifications: state.notifications.map((n) => ({ ...n, is_read: true }))
+    }))
+    const { error } = await supabase
+      .from('event_notifications')
+      .update({ is_read: true })
+      .in('id', unreadIds)
+    if (error) console.error('Error marking all notifications read:', error)
+  },
+
+  teardown: () => {
+    const channel = get()._channel
+    if (channel) supabase.removeChannel(channel)
+    set({ _channel: null, familyId: null, notifications: [] })
+  }
+}))

--- a/packages/frontend/src/store/useNotificationsStore.js
+++ b/packages/frontend/src/store/useNotificationsStore.js
@@ -27,6 +27,10 @@ export const useNotificationsStore = create((set, get) => ({
       .order('created_at', { ascending: false })
       .limit(50)
 
+    // teardown() (e.g. logout) may have run during the await; if the active
+    // family changed, bail without mutating state or leaking a subscription.
+    if (get().familyId !== familyId) return
+
     if (error) {
       console.error('Error fetching notifications:', error)
       set({ error: error.message, loading: false })

--- a/packages/netlify/functions/telegram-alert.mts
+++ b/packages/netlify/functions/telegram-alert.mts
@@ -180,18 +180,6 @@ export const handler: Handler = async (event: HandlerEvent, context: HandlerCont
        message = `🗑️ *Event Deleted*\n\n*${eventTitle}*\nDate: ${eventDate}`;
     }
 
-    if (action === 'rsvp') {
-      const rsvpStatus = (data.rsvpStatus || '').toLowerCase();
-      const rsvpMeta: Record<string, { emoji: string; text: string }> = {
-        yes:   { emoji: '✅', text: 'is attending' },
-        maybe: { emoji: '🤔', text: 'might attend' },
-        no:    { emoji: '❌', text: 'is not attending' }
-      };
-      const meta = rsvpMeta[rsvpStatus] || { emoji: '📝', text: `RSVP'd: ${rsvpStatus || 'unknown'}` };
-      const rsvpFamily = familyName && familyName !== 'Unknown' ? `The ${familyName} family` : 'A family';
-      message = `${meta.emoji} *RSVP Update*\n\n*${rsvpFamily}* ${meta.text} *${eventTitle}*.\nLink: ${eventUrl}`;
-    }
-
     // Send to Telegram
     const response = await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
       method: 'POST',

--- a/packages/supabase/migrations/20260530000000_event_notifications.sql
+++ b/packages/supabase/migrations/20260530000000_event_notifications.sql
@@ -1,0 +1,119 @@
+-- In-app event notifications: let a host family know when someone RSVPs to their event.
+-- A generic "notifications" table already exists (abandoned stub, world-readable RLS),
+-- so this uses a dedicated, privacy-scoped table instead.
+-- Backed by a SECURITY DEFINER trigger on event_attendees, surfaced live in the PWA
+-- via Supabase Realtime.
+
+-- 1. Table (denormalized actor name + event title so Realtime INSERT payloads
+--    render in the UI without extra joins)
+CREATE TABLE IF NOT EXISTS "public"."event_notifications" (
+  "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+  "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+  "recipient_family_id" "uuid" NOT NULL,
+  "actor_family_id" "uuid",
+  "event_id" "uuid",
+  "type" "text" NOT NULL DEFAULT 'rsvp',
+  "rsvp_status" "text",
+  "actor_family_name" "text",
+  "event_title" "text",
+  "is_read" boolean NOT NULL DEFAULT false,
+  CONSTRAINT "event_notifications_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "event_notifications_recipient_family_id_fkey"
+    FOREIGN KEY ("recipient_family_id") REFERENCES "public"."family_groups"("id") ON DELETE CASCADE,
+  CONSTRAINT "event_notifications_actor_family_id_fkey"
+    FOREIGN KEY ("actor_family_id") REFERENCES "public"."family_groups"("id") ON DELETE SET NULL,
+  CONSTRAINT "event_notifications_event_id_fkey"
+    FOREIGN KEY ("event_id") REFERENCES "public"."family_calendar"("id") ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "idx_event_notifications_recipient"
+  ON "public"."event_notifications" USING "btree" ("recipient_family_id", "is_read", "created_at" DESC);
+
+-- 2. RLS: a family reads/updates only its own notifications.
+--    No INSERT policy — rows are created exclusively by the trigger below.
+ALTER TABLE "public"."event_notifications" ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE policyname = 'Family can read its event notifications' AND tablename = 'event_notifications'
+  ) THEN
+    CREATE POLICY "Family can read its event notifications"
+      ON "public"."event_notifications" FOR SELECT TO "authenticated"
+      USING ("recipient_family_id" = ( SELECT "profiles"."family_id"
+        FROM "public"."profiles" WHERE ("profiles"."id" = "auth"."uid"())));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE policyname = 'Family can update its event notifications' AND tablename = 'event_notifications'
+  ) THEN
+    CREATE POLICY "Family can update its event notifications"
+      ON "public"."event_notifications" FOR UPDATE TO "authenticated"
+      USING ("recipient_family_id" = ( SELECT "profiles"."family_id"
+        FROM "public"."profiles" WHERE ("profiles"."id" = "auth"."uid"())))
+      WITH CHECK ("recipient_family_id" = ( SELECT "profiles"."family_id"
+        FROM "public"."profiles" WHERE ("profiles"."id" = "auth"."uid"())));
+  END IF;
+END $$;
+
+-- 3. Trigger: on RSVP insert/update, notify the event's host family.
+CREATE OR REPLACE FUNCTION "public"."notify_host_on_rsvp"()
+RETURNS "trigger"
+LANGUAGE "plpgsql"
+SECURITY DEFINER
+SET "search_path" = "public"
+AS $$
+DECLARE
+  v_host_family_id uuid;
+  v_event_title text;
+  v_actor_name text;
+BEGIN
+  -- On UPDATE, only fire when the choice actually changed.
+  IF (TG_OP = 'UPDATE' AND NEW.rsvp_status IS NOT DISTINCT FROM OLD.rsvp_status) THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT family_id, event_title
+    INTO v_host_family_id, v_event_title
+    FROM public.family_calendar
+   WHERE id = NEW.event_id;
+
+  -- No host on the event, or the host family is the one RSVPing -> skip.
+  IF v_host_family_id IS NULL OR v_host_family_id = NEW.family_id THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT family_last_name INTO v_actor_name
+    FROM public.family_groups WHERE id = NEW.family_id;
+
+  INSERT INTO public.event_notifications (
+    recipient_family_id, actor_family_id, event_id,
+    type, rsvp_status, actor_family_name, event_title
+  ) VALUES (
+    v_host_family_id, NEW.family_id, NEW.event_id,
+    'rsvp', NEW.rsvp_status, COALESCE(v_actor_name, 'A family'), v_event_title
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS "trg_notify_host_on_rsvp" ON "public"."event_attendees";
+CREATE TRIGGER "trg_notify_host_on_rsvp"
+  AFTER INSERT OR UPDATE ON "public"."event_attendees"
+  FOR EACH ROW EXECUTE FUNCTION "public"."notify_host_on_rsvp"();
+
+-- 4. Stream new notifications to the PWA in real time.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'event_notifications'
+  ) THEN
+    ALTER PUBLICATION "supabase_realtime" ADD TABLE "public"."event_notifications";
+  END IF;
+END $$;

--- a/packages/supabase/migrations/20260530000001_event_notifications_update_guard.sql
+++ b/packages/supabase/migrations/20260530000001_event_notifications_update_guard.sql
@@ -1,0 +1,6 @@
+-- Harden event_notifications updates: a family may only flip is_read, never
+-- rewrite a notification's content. RLS WITH CHECK cannot compare OLD vs NEW,
+-- so this is enforced with a column-level UPDATE privilege.
+-- (anon is already blocked from updating by the "authenticated"-only RLS policy.)
+REVOKE UPDATE ON "public"."event_notifications" FROM "authenticated";
+GRANT UPDATE ("is_read") ON "public"."event_notifications" TO "authenticated";


### PR DESCRIPTION
Replace the group Telegram RSVP alert with a privacy-scoped, host-targeted in-app notification center.

- drop RSVP Telegram alert from EventRSVPButton + the 'rsvp' branch in telegram-alert
- event_notifications table + RLS (family reads/updates only its own), SECURITY DEFINER trigger on event_attendees that notifies the event's host family, added to supabase_realtime
- useNotificationsStore: fetch + Realtime subscribe + mark read
- NotificationBell in Nav with unread badge, links to the event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app notification system for RSVP activity with a notification bell in the header, dropdown list, relative timestamps, and unread styling.

* **Changes**
  * RSVP buttons now update status in-app and show toast feedback without sending external alerts.
  * Notifications can be marked read individually or marked all read; tapping a notification may navigate to the related event.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/repolife/bible-reading-plan/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->